### PR TITLE
Add TestBoom submod

### DIFF
--- a/testboom/build.gradle
+++ b/testboom/build.gradle
@@ -1,0 +1,30 @@
+buildscript {
+    repositories {
+        maven { url = 'https://maven.minecraftforge.net/' }
+        maven { url = 'https://plugins.gradle.org/m2' }
+        mavenCentral()
+    }
+    dependencies {
+        classpath('com.anatawa12.forge:ForgeGradle:1.2-1.0.+') { changing = true }
+    }
+}
+
+apply plugin: 'forge'
+
+archivesBaseName = 'TestBoom'
+version = '1.0'
+group = 'com.testboom'
+sourceCompatibility = targetCompatibility = '1.8'
+
+minecraft {
+version = '1.7.10-10.13.4.1614-1.7.10'
+runDir = 'eclipse'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation fileTree(dir: '../build/libs', include: 'HBM-NTM-*.jar')
+}

--- a/testboom/src/main/java/com/testboom/ItemTestBoom.java
+++ b/testboom/src/main/java/com/testboom/ItemTestBoom.java
@@ -1,0 +1,30 @@
+package com.testboom;
+
+import java.util.List;
+
+import com.hbm.config.BombConfig;
+import com.hbm.entity.logic.EntityNukeExplosionMK5;
+
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
+
+public class ItemTestBoom extends Item {
+	@Override
+	public boolean onEntityItemUpdate(EntityItem entityItem) {
+		if(entityItem != null && !entityItem.worldObj.isRemote && entityItem.onGround) {
+			entityItem.worldObj.spawnEntityInWorld(EntityNukeExplosionMK5.statFac(entityItem.worldObj, BombConfig.boyRadius, entityItem.posX, entityItem.posY, entityItem.posZ));
+			entityItem.worldObj.playSoundEffect(entityItem.posX, entityItem.posY, entityItem.posZ, "random.explode", 1.0F, entityItem.worldObj.rand.nextFloat() * 0.1F + 0.9F);
+			entityItem.setDead();
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean bool) {
+		list.add(EnumChatFormatting.RED + "[Drop to detonate]");
+	}
+}

--- a/testboom/src/main/java/com/testboom/TestBoomMod.java
+++ b/testboom/src/main/java/com/testboom/TestBoomMod.java
@@ -1,0 +1,18 @@
+package com.testboom;
+
+import net.minecraft.item.Item;
+import cpw.mods.fml.common.Mod;
+import cpw.mods.fml.common.Mod.EventHandler;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
+
+@Mod(modid = TestBoomMod.MODID, name = "Test Boom", version = "1.0", dependencies = "required-after:hbm")
+public class TestBoomMod {
+	public static final String MODID = "testboom";
+	public static Item testboom;
+	@EventHandler
+	public void preInit(FMLPreInitializationEvent event) {
+		testboom = new ItemTestBoom().setUnlocalizedName("testboom").setTextureName(MODID + ":testboom");
+		GameRegistry.registerItem(testboom, "testboom");
+	}
+}

--- a/testboom/src/main/resources/assets/testboom/lang/en_US.lang
+++ b/testboom/src/main/resources/assets/testboom/lang/en_US.lang
@@ -1,0 +1,1 @@
+item.testboom.name=Test Boom

--- a/testboom/src/main/resources/mcmod.info
+++ b/testboom/src/main/resources/mcmod.info
@@ -1,0 +1,15 @@
+[
+  {
+    "modid": "testboom",
+    "name": "Test Boom",
+    "description": "Demonstration submod for HBM NTM",
+    "version": "1.0",
+    "mcversion": "1.7.10",
+    "url": "",
+    "updateUrl": "",
+    "credits": "",
+    "logoFile": "",
+    "screenshots": [],
+    "dependencies": ["required-after:hbm"]
+  }
+]


### PR DESCRIPTION
## Summary
- add a minimal example submod `TestBoom`
- register a test item that explodes using Little Boy's logic when dropped
- clean up CRLF line endings and update Gradle buildscript

## Testing
- `./gradlew --version` *(fails: Could not determine java version)*


------
https://chatgpt.com/codex/tasks/task_e_6844534bf5948320ba08ab2f44f4cb6e