### PR TITLE
Add testboom item that detonates on drop

### DIFF
--- a/src/main/java/com/hbm/items/ModItems.java
+++ b/src/main/java/com/hbm/items/ModItems.java
@@ -837,6 +837,7 @@ public class ModItems {
 	public static Item black_hole;
 	public static Item singularity_spark;
 	public static Item crystal_xen;
+	public static Item testboom;
 	public static Item inf_water;
 	public static Item inf_water_mk2;
 
@@ -2898,6 +2899,7 @@ public class ModItems {
 		singularity_spark = new ItemDrop().setUnlocalizedName("singularity_spark").setMaxStackSize(1).setCreativeTab(MainRegistry.controlTab).setContainerItem(ModItems.nuclear_waste).setTextureName(RefStrings.MODID + ":singularity_spark_alt");
 		pellet_antimatter = new ItemDrop().setUnlocalizedName("pellet_antimatter").setCreativeTab(MainRegistry.controlTab).setContainerItem(ModItems.cell_empty).setTextureName(RefStrings.MODID + ":pellet_antimatter");
 		crystal_xen = new ItemDrop().setUnlocalizedName("crystal_xen").setMaxStackSize(1).setCreativeTab(MainRegistry.controlTab).setTextureName(RefStrings.MODID + ":crystal_xen");
+		testboom = new ItemTestBoom().setUnlocalizedName("testboom").setCreativeTab(MainRegistry.nukeTab).setTextureName(RefStrings.MODID + ":testboom");
 
 		stamp_stone_flat = new ItemStamp(32, StampType.FLAT).setUnlocalizedName("stamp_stone_flat").setMaxStackSize(1).setCreativeTab(MainRegistry.controlTab).setTextureName(RefStrings.MODID + ":stamp_stone_flat");
 		stamp_stone_plate = new ItemStamp(32, StampType.PLATE).setUnlocalizedName("stamp_stone_plate").setMaxStackSize(1).setCreativeTab(MainRegistry.controlTab).setTextureName(RefStrings.MODID + ":stamp_stone_plate");
@@ -5669,6 +5671,7 @@ public class ModItems {
 		GameRegistry.registerItem(black_hole, black_hole.getUnlocalizedName());
 		GameRegistry.registerItem(singularity_spark, singularity_spark.getUnlocalizedName());
 		GameRegistry.registerItem(crystal_xen, crystal_xen.getUnlocalizedName());
+		GameRegistry.registerItem(testboom, testboom.getUnlocalizedName());
 		GameRegistry.registerItem(pellet_antimatter, pellet_antimatter.getUnlocalizedName());
 
 		//Infinite Tanks

--- a/src/main/java/com/hbm/items/special/ItemTestBoom.java
+++ b/src/main/java/com/hbm/items/special/ItemTestBoom.java
@@ -1,0 +1,23 @@
+package com.hbm.items.special;
+
+import com.hbm.config.BombConfig;
+import com.hbm.entity.logic.EntityNukeExplosionMK5;
+
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.item.Item;
+import net.minecraft.world.World;
+
+public class ItemTestBoom extends Item {
+
+	@Override
+	public boolean onEntityItemUpdate(EntityItem entityItem) {
+		if(entityItem != null && entityItem.onGround && !entityItem.worldObj.isRemote) {
+		World world = entityItem.worldObj;
+		world.spawnEntityInWorld(EntityNukeExplosionMK5.statFac(world, BombConfig.boyRadius, entityItem.posX, entityItem.posY, entityItem.posZ));
+		entityItem.setDead();
+		return true;
+	}
+	return false;
+	}
+}
+

--- a/src/main/resources/assets/hbm/lang/de_DE.lang
+++ b/src/main/resources/assets/hbm/lang/de_DE.lang
@@ -5015,3 +5015,4 @@ weapon.ability.radiation=Radioaktive Schneide
 weapon.ability.phosphorus=Phosphorspitze
 weapon.ability.stun=Betäubend
 weapon.ability.vampire=Vampir
+item.testboom.name=Testboom

--- a/src/main/resources/assets/hbm/lang/en_US.lang
+++ b/src/main/resources/assets/hbm/lang/en_US.lang
@@ -6211,3 +6211,4 @@ desc.gui.upgrade.effectiveness= * §aEffectiveness§r: Stacks to level 3
 desc.gui.upgrade.overdrive= * §7Overdrive§r: Stacks to level 3
 desc.gui.upgrade.power= * §1Power-Saving§r: Stacks to level 3
 desc.gui.upgrade.speed= * §4Speed§r: Stacks to level 3
+item.testboom.name=Testboom

--- a/src/main/resources/assets/hbm/lang/fr_FR.lang
+++ b/src/main/resources/assets/hbm/lang/fr_FR.lang
@@ -1567,3 +1567,4 @@ tile.taint.name=Taint
 
 tile.cheater_virus.name=Euphemium gélifié
 tile.cheater_virus_seed.name=Bloc de schrabide Euphemium instable
+item.testboom.name=Testboom

--- a/src/main/resources/assets/hbm/lang/it_IT.lang
+++ b/src/main/resources/assets/hbm/lang/it_IT.lang
@@ -6232,3 +6232,4 @@ desc.gui.upgrade.effectiveness= * §aEffectiveness§r: Stacks to level 3
 desc.gui.upgrade.overdrive= * §7Overdrive§r: Stacks to level 3
 desc.gui.upgrade.power= * §1Power-Saving§r: Stacks to level 3
 desc.gui.upgrade.speed= * §4Speed§r: Stacks to level 3
+item.testboom.name=Testboom

--- a/src/main/resources/assets/hbm/lang/pl_PL.lang
+++ b/src/main/resources/assets/hbm/lang/pl_PL.lang
@@ -5442,3 +5442,4 @@ weapon.elecGun.glass_cannon.visible=Visible Light
 weapon.elecGun.glass_cannon.uv=Ultraviolet Light
 weapon.elecGun.glass_cannon.xray=X-rays
 weapon.elecGun.glass_cannon.gamma=Gamma rays
+item.testboom.name=Testboom

--- a/src/main/resources/assets/hbm/lang/ru_RU.lang
+++ b/src/main/resources/assets/hbm/lang/ru_RU.lang
@@ -6446,3 +6446,4 @@ desc.gui.upgrade.effectiveness= * §aЭффективность§r: Стакае
 desc.gui.upgrade.overdrive= * §7Перегруз§r: Стакается до 3-х уровней
 desc.gui.upgrade.power= * §1Энергосбережение§r: Стакается до 3-х уровней
 desc.gui.upgrade.speed= * §4Скорость§r: Стакается до 3-х уровней
+item.testboom.name=Testboom

--- a/src/main/resources/assets/hbm/lang/uk_UA.lang
+++ b/src/main/resources/assets/hbm/lang/uk_UA.lang
@@ -6194,3 +6194,4 @@ desc.gui.upgrade.effectiveness= * §aЕфективність§r: Складає
 desc.gui.upgrade.overdrive= * §7Перевантаження§r: Складається до 3 рівнів
 desc.gui.upgrade.power= * §1Енергозбереження§r: Складається до 3 рівнів
 desc.gui.upgrade.speed= * §4Швидкість§r: Складається до 3 рівнів
+item.testboom.name=Testboom

--- a/src/main/resources/assets/hbm/lang/zh_CN.lang
+++ b/src/main/resources/assets/hbm/lang/zh_CN.lang
@@ -6072,3 +6072,4 @@ item.ammo_secret.bmg50_black.name=.50BMG旁道者弹药
 item.ammo_standard.bmg50_sm.name=.50BMG子弹（星辉）
 item.gun_amat_penance.name=忏悔
 item.gun_amat_subtlety.name=明敏
+item.testboom.name=Testboom


### PR DESCRIPTION
## Summary
- introduce `ItemTestBoom` that spawns an MK5 explosion with Little Boy yield when dropped
- register new `testboom` item in `ModItems`
- add language entries for `testboom`
- fix formatting and localization issues from prior commit

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68445cf75c7483209b6caf7d8bab3108